### PR TITLE
two changes to XDI as discussed

### DIFF
--- a/src/main/java/fi/hiit/dime/LinkContractsController.java
+++ b/src/main/java/fi/hiit/dime/LinkContractsController.java
@@ -103,10 +103,15 @@ public class LinkContractsController extends AuthorizedController {
 				if (linkContractContextNode.getXDIAddress().toString().contains("$defer")) continue;
 
 				RelationshipLinkContract linkContract = (RelationshipLinkContract) LinkContract.fromContextNode(linkContractContextNode);
+				String address = linkContract.getContextNode().getXDIAddress().toString();
+				String authorizingAuthority = linkContract.getAuthorizingAuthority().toString();
+				String requestingAuthority = linkContract.getRequestingAuthority().toString();
+				String direction = XdiService.findProfileByDidXDIAddress(linkContract.getAuthorizingAuthority()) != null ? "outgoing" : "incoming";
 				result.add(new XdiLinkContract(
-						linkContract.getContextNode().getXDIAddress().toString(), 
-						linkContract.getAuthorizingAuthority().toString(),
-						linkContract.getRequestingAuthority().toString()));
+						address, 
+						authorizingAuthority,
+						requestingAuthority,
+						direction));
 			}
 		}
 
@@ -287,7 +292,8 @@ public class LinkContractsController extends AuthorizedController {
 		public String address;
 		public String authorizingAuthority;
 		public String requestingAuthority;
-		public XdiLinkContract(String address, String authorizingAuthority, String requestingAuthority) { this.address = address; this.authorizingAuthority = authorizingAuthority; this.requestingAuthority = requestingAuthority;} 
+		public String direction;
+		public XdiLinkContract(String address, String authorizingAuthority, String requestingAuthority, String direction) { this.address = address; this.authorizingAuthority = authorizingAuthority; this.requestingAuthority = requestingAuthority; this.direction = direction; } 
 	}
 	
 	private static class XdiData {

--- a/src/main/java/fi/hiit/dime/RequestsController.java
+++ b/src/main/java/fi/hiit/dime/RequestsController.java
@@ -50,19 +50,27 @@ import xdi2.client.impl.local.XDILocalClient;
 import xdi2.core.ContextNode;
 import xdi2.core.Graph;
 import xdi2.core.bootstrap.XDIBootstrap;
+import xdi2.core.constants.XDILinkContractConstants;
 import xdi2.core.features.aggregation.Aggregation;
+import xdi2.core.features.index.Index;
 import xdi2.core.features.linkcontracts.instance.ConnectLinkContract;
+import xdi2.core.features.linkcontracts.instance.LinkContract;
 import xdi2.core.features.linkcontracts.instance.RootLinkContract;
+import xdi2.core.features.nodetypes.XdiEntityCollection;
 import xdi2.core.features.nodetypes.XdiPeerRoot;
 import xdi2.core.syntax.XDIAddress;
 import xdi2.core.syntax.XDIArc;
+import xdi2.core.util.CopyUtil;
 import xdi2.core.util.XDIAddressUtil;
 import xdi2.core.util.iterators.EmptyIterator;
 import xdi2.core.util.iterators.ReadOnlyIterator;
 import xdi2.messaging.Message;
 import xdi2.messaging.MessageEnvelope;
+import xdi2.messaging.constants.XDIMessagingConstants;
 import xdi2.messaging.container.MessagingContainer;
 import xdi2.messaging.operations.Operation;
+import xdi2.messaging.response.FullMessagingResponse;
+import xdi2.messaging.response.MessagingResponse;
 
 /**
  * Requests API controller.
@@ -105,12 +113,14 @@ public class RequestsController extends AuthorizedController {
 		message.setFromXDIAddress(senderXDIAddress);
 		message.setToXDIAddress(targetXDIAddress);
 		message.setLinkContractClass(ConnectLinkContract.class);
+		message.setParameter(XDIMessagingConstants.XDI_ADD_MESSAGE_PARAMETER_MSG, Boolean.TRUE);
 		Operation operation = message.createConnectOperation(XDIBootstrap.GET_LINK_CONTRACT_TEMPLATE_ADDRESS);
 		operation.setVariableValue(XDIArc.create("{$get}"), XDIAddressUtil.concatXDIAddresses(targetXDIAddress, XDIAddress.create("#dime")));
 
 		// send to XDI target
 
 		XDIAbstractClient<?> client = (XDIAbstractClient<?>) route.constructXDIClient();
+		MessagingResponse messagingResponse;
 
 		try {
 
@@ -119,10 +129,19 @@ public class RequestsController extends AuthorizedController {
 			manipulator.setSignatureCreator(signatureCreator);
 			client.getManipulators().addManipulator(manipulator);*/
 
-			client.send(message.getMessageEnvelope());
+			messagingResponse = client.send(message.getMessageEnvelope());
 		} catch (Xdi2ClientException ex) {
 
 			throw new RuntimeException(ex.getMessage(), ex);
+		}
+
+		for (LinkContract pushLinkContract : FullMessagingResponse.getDeferredPushLinkContracts(messagingResponse)) {
+
+			// write push link contract and index into graph
+
+			CopyUtil.copyContextNode(pushLinkContract.getContextNode(), XdiService.get().myGraph(profile), null);
+			XdiEntityCollection xdiLinkContractIndex = Index.getEntityIndex(XdiService.get().myGraph(profile), XDILinkContractConstants.XDI_ARC_CONTRACT, true);
+			Index.setEntityIndexAggregation(xdiLinkContractIndex, pushLinkContract.getXdiEntity().getXDIAddress());
 		}
 
 		// done

--- a/src/main/java/fi/hiit/dime/RequestsController.java
+++ b/src/main/java/fi/hiit/dime/RequestsController.java
@@ -50,10 +50,10 @@ import xdi2.client.impl.local.XDILocalClient;
 import xdi2.core.ContextNode;
 import xdi2.core.Graph;
 import xdi2.core.bootstrap.XDIBootstrap;
-import xdi2.core.exceptions.Xdi2Exception;
 import xdi2.core.features.aggregation.Aggregation;
 import xdi2.core.features.linkcontracts.instance.ConnectLinkContract;
 import xdi2.core.features.linkcontracts.instance.RootLinkContract;
+import xdi2.core.features.nodetypes.XdiPeerRoot;
 import xdi2.core.syntax.XDIAddress;
 import xdi2.core.syntax.XDIArc;
 import xdi2.core.util.XDIAddressUtil;
@@ -84,8 +84,7 @@ public class RequestsController extends AuthorizedController {
 			throws NotFoundException, BadRequestException
 	{
 		Profile profile = XdiService.get().profileDAO.profilesForUser(getUser(auth).getId()).get(0);
-		XDIAddress didXDIAddress = XdiService.getProfileDidXDIAddress(profile);
-
+		XDIAddress senderXDIAddress = XdiService.getProfileDidXDIAddress(profile);
 		XDIAddress targetXDIAddress = XDIAddress.create(target);
 
 		// find XDI route
@@ -94,16 +93,16 @@ public class RequestsController extends AuthorizedController {
 
 		try {
 
-			route = XdiService.get().getXDIAgent().route(targetXDIAddress);
-		} catch (Xdi2Exception ex) {
+			route = XdiService.get().getXDIAgent().route(XdiPeerRoot.createPeerRootXDIArc(targetXDIAddress));
+		} catch (Exception ex) {
 
 			throw new RuntimeException(ex.getMessage(), ex);
 		}
 
 		// build XDI message
 
-		Message message = route.createMessage(didXDIAddress, -1);
-		message.setFromXDIAddress(didXDIAddress);
+		Message message = route.createMessage(senderXDIAddress, -1);
+		message.setFromXDIAddress(senderXDIAddress);
 		message.setToXDIAddress(targetXDIAddress);
 		message.setLinkContractClass(ConnectLinkContract.class);
 		Operation operation = message.createConnectOperation(XDIBootstrap.GET_LINK_CONTRACT_TEMPLATE_ADDRESS);

--- a/src/main/java/fi/hiit/dime/xdi/DiMeMessagingContainerFactory.java
+++ b/src/main/java/fi/hiit/dime/xdi/DiMeMessagingContainerFactory.java
@@ -44,6 +44,11 @@ public class DiMeMessagingContainerFactory extends PrototypingUriMessagingContai
 			throw new Xdi2TransportException("Invalid owner string " + ownerString + ": " + ex.getMessage(), ex);
 		}
 
+		// check if a profile with DID exists
+
+		boolean exists = XdiService.findProfileByDidXDIAddress(ownerXDIAddress) != null;
+		if (! exists) return null;
+
 		// create and mount the new messaging container
 
 		String messagingContainerPath = messagingContainerFactoryPath + "/" + ownerXDIAddress.toString();

--- a/src/main/java/fi/hiit/dime/xdi/XdiSovrinAgentRouter.java
+++ b/src/main/java/fi/hiit/dime/xdi/XdiSovrinAgentRouter.java
@@ -1,0 +1,145 @@
+package fi.hiit.dime.xdi;
+
+import java.net.URI;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.hyperledger.indy.sdk.ledger.Ledger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonNull;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+
+import fi.hiit.dime.authentication.CurrentUser;
+import fi.hiit.dime.authentication.User;
+import fi.hiit.dime.data.Profile;
+import fi.hiit.dime.sovrin.SovrinService;
+import xdi2.agent.routing.XDIAgentRouter;
+import xdi2.client.exceptions.Xdi2AgentException;
+import xdi2.client.impl.http.XDIHttpClient;
+import xdi2.client.impl.http.XDIHttpClientRoute;
+import xdi2.core.features.nodetypes.XdiPeerRoot;
+import xdi2.core.syntax.XDIArc;
+
+public class XdiSovrinAgentRouter implements XDIAgentRouter<XDIHttpClientRoute, XDIHttpClient> {
+
+	private static final Logger LOG =
+			LoggerFactory.getLogger(XdiSovrinAgentRouter.class);
+
+	public static final int RETRIES = 3;
+
+	public static final Gson gson = new Gson();
+
+	@Override
+	public XDIHttpClientRoute route(XDIArc toPeerRootXDIArc) throws Xdi2AgentException {
+
+		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+		User user = ((CurrentUser) authentication.getPrincipal()).getUser();
+		Profile profile = XdiService.get().profileDAO.profilesForUser(user.getId()).get(0);
+
+		String submitterDid = XdiService.didStringFromXDIAddress(XdiService.getProfileDidXDIAddress(profile));
+		String targetDid = XdiService.didStringFromXDIAddress(XdiPeerRoot.getXDIAddressOfPeerRootXDIArc(toPeerRootXDIArc));
+
+		// GET_NYM request
+
+		String indyRequest1 = null;
+		String indyResult1 = null;
+
+		try {
+
+			for (int i=0; i<RETRIES; i++) {
+
+				try {
+
+					indyRequest1 = Ledger.buildGetNymRequest(submitterDid, targetDid).get(5, TimeUnit.SECONDS);
+					LOG.info("Retry #" + i + ": Success: " + indyRequest1);
+					break;
+				} catch (TimeoutException ex) {
+
+					LOG.warn("Retry #" + i + ": " + ex.getMessage());
+					if (i+1 < RETRIES) continue; else throw ex;
+				}
+			}
+
+			for (int i=0; i<RETRIES; i++) {
+
+				try {
+
+					indyResult1 = Ledger.signAndSubmitRequest(SovrinService.get().getPool(), SovrinService.get().getWallet(), submitterDid, indyRequest1).get(5, TimeUnit.SECONDS);
+					LOG.info("Retry #" + i + ": Success: " + indyResult1);
+					break;
+				} catch (TimeoutException ex) {
+
+					LOG.warn("Retry #" + i + ": " + ex.getMessage());
+					if (i+1 < RETRIES) continue; else throw ex;
+				}
+			}
+		} catch (Exception ex) {
+
+			throw new RuntimeException("Cannot execute GET_NYM in Sovrin: " + ex.getMessage(), ex);
+		}
+
+		// GET_ATTR request
+
+		String indyRequest2 = null;
+		String indyResult2 = null;
+
+		try {
+
+			for (int i=0; i<RETRIES; i++) {
+
+				try {
+
+					indyRequest2 = Ledger.buildGetAttribRequest(submitterDid, targetDid, "endpoint").get(5, TimeUnit.SECONDS);;
+					LOG.info("Retry #" + i + ": Success: " + indyRequest2);
+					break;
+				} catch (TimeoutException ex) {
+
+					LOG.warn("Retry #" + i + ": " + ex.getMessage());
+					if (i+1 < RETRIES) continue; else throw ex;
+				}
+			}
+
+			for (int i=0; i<RETRIES; i++) {
+
+				try {
+
+					indyResult2 = Ledger.signAndSubmitRequest(SovrinService.get().getPool(), SovrinService.get().getWallet(), submitterDid, indyRequest2).get(5, TimeUnit.SECONDS);
+					LOG.info("Retry #" + i + ": Success: " + indyResult2);
+					break;
+				} catch (TimeoutException ex) {
+
+					LOG.warn("Retry #" + i + ": " + ex.getMessage());
+					if (i+1 < RETRIES) continue; else throw ex;
+				}
+			}
+		} catch (Exception ex) {
+
+			throw new RuntimeException("Cannot execute GET_ATTR in Sovrin: " + ex.getMessage(), ex);
+		}
+
+		// result data
+
+		JsonObject jsonReply2 = gson.fromJson(indyResult2, JsonObject.class);
+
+		JsonObject result2 = jsonReply2 == null ? null : jsonReply2.getAsJsonObject("result");
+		JsonElement dataString2 = result2 == null ? null : result2.get("data");
+		JsonObject data2 = (dataString2 == null || dataString2 instanceof JsonNull) ? null : gson.fromJson(dataString2.getAsString(), JsonObject.class);
+
+		// extract XDI endpoint URI
+
+		JsonObject endpointJsonObject = data2 == null ? null : data2.getAsJsonObject("endpoint");
+		JsonPrimitive xdiEndpointJsonElement = endpointJsonObject == null ? null : endpointJsonObject.getAsJsonPrimitive("xdi");
+		String xdiEndpoint = xdiEndpointJsonElement == null ? null : xdiEndpointJsonElement.getAsString();
+
+		// return XDI route
+
+		return new XDIHttpClientRoute(toPeerRootXDIArc, URI.create(xdiEndpoint));
+	}
+}

--- a/src/main/resources/xdi-applicationContext.xml
+++ b/src/main/resources/xdi-applicationContext.xml
@@ -48,6 +48,14 @@
 		<property name="agentRouters">
 			<util:list>
 				<bean class="xdi2.agent.routing.impl.bootstrap.XDIBootstrapLocalAgentRouter" />
+				<bean class="xdi2.agent.routing.impl.local.XDIMessagingContainerRegistryAgentRouter">
+					<property name="messagingContainerRegistry" ref="UriMessagingContainerRegistry" />
+					<property name="interceptors">
+						<util:list>
+							<ref bean="DebugHttpTransportInterceptor" />
+						</util:list>
+					</property>
+				</bean>
 				<bean class="fi.hiit.dime.xdi.XdiSovrinAgentRouter" />
 <!-- 				<bean class="xdi2.agent.routing.impl.http.XDIHttpDiscoveryAgentRouter">
 					<property name="xdiDiscoveryClient" ref="XDIDiscoveryClient" />
@@ -161,14 +169,14 @@
 						</util:list>
 					</property> -->
 				</bean>
-<!-- 				<bean class="xdi2.messaging.container.interceptor.impl.push.PushInInterceptor" />
+				<bean class="xdi2.messaging.container.interceptor.impl.push.PushInInterceptor" />
 				<bean class="xdi2.messaging.container.interceptor.impl.push.PushOutInterceptor">
 					<property name="pushGateway">
 						<bean class="xdi2.messaging.container.interceptor.impl.push.BasicPushGateway">
 							<property name="xdiAgent" ref="XDIAgent" />
 						</bean>
 					</property>
-				</bean> -->
+				</bean>
 				<bean class="xdi2.messaging.container.interceptor.impl.defer.DeferResultInterceptor" />
 			</util:list>
 		</property>

--- a/src/main/resources/xdi-applicationContext.xml
+++ b/src/main/resources/xdi-applicationContext.xml
@@ -40,17 +40,18 @@
 
 	<!-- XDI DISCOVERY CLIENT AND AGENT -->
 
-	<bean id="XDIDiscoveryClient" class="xdi2.discovery.XDIDiscoveryClient">
+<!-- 	<bean id="XDIDiscoveryClient" class="xdi2.discovery.XDIDiscoveryClient">
 		<property name="registryXdiClient" value="https://xdi.sovrin.at/" />
-	</bean>
+	</bean> -->
 
 	<bean id="XDIAgent" class="xdi2.agent.impl.XDIBasicAgent">
 		<property name="agentRouters">
 			<util:list>
 				<bean class="xdi2.agent.routing.impl.bootstrap.XDIBootstrapLocalAgentRouter" />
-				<bean class="xdi2.agent.routing.impl.http.XDIHttpDiscoveryAgentRouter">
+				<bean class="fi.hiit.dime.xdi.XdiSovrinAgentRouter" />
+<!-- 				<bean class="xdi2.agent.routing.impl.http.XDIHttpDiscoveryAgentRouter">
 					<property name="xdiDiscoveryClient" ref="XDIDiscoveryClient" />
-				</bean>
+				</bean> -->
 			</util:list>
 		</property>
 	</bean>


### PR DESCRIPTION
1. For routing XDI messages, look up XDI endpoint directly from Sovrin ledger, instead of contacting xdi.sovrin.at discovery service.
2. support for viewing both incoming and outgoing link contracts